### PR TITLE
Release v2026.0.0-rc.9

### DIFF
--- a/fhirpkg.lock.json
+++ b/fhirpkg.lock.json
@@ -1,0 +1,23 @@
+{
+  "updated": "2025-12-18T07:57:03.685039+01:00",
+  "dependencies": {
+    "de.basisprofil.r4": "1.5.4",
+    "hl7.fhir.r4.core": "4.0.1",
+    "de.medizininformatikinitiative.kerndatensatz.medikation": "2025.0.1",
+    "hl7.fhir.uv.ips": "1.1.0",
+    "fhir.dicom": "2022.4.20221006",
+    "de.ihe-d.terminology": "3.0.1",
+    "de.medizininformatikinitiative.kerndatensatz.meta": "2026.0.0",
+    "de.medizininformatikinitiative.kerndatensatz.molgen": "2026.0.2",
+    "hl7.terminology.r4": "6.1.0",
+    "hl7.fhir.uv.genomics-reporting": "3.0.0",
+    "hl7.fhir.uv.extensions.r4": "5.1.0",
+    "eu.miabis.r4": "0.2.0",
+    "de.medizininformatikinitiative.kerndatensatz.diagnose": "2025.0.1",
+    "kbv.all.st": "1.27.0",
+    "de.medizininformatikinitiative.kerndatensatz.prozedur": "2025.0.1",
+    "de.medizininformatikinitiative.kerndatensatz.base": "2026.0.0",
+    "de.medizininformatikinitiative.kerndatensatz.studie": "2026.0.0-ballot"
+  },
+  "missing": {}
+}

--- a/fsh-generated/resources/ImplementationGuide-mii-ig-onko-de-v2025.json
+++ b/fsh-generated/resources/ImplementationGuide-mii-ig-onko-de-v2025.json
@@ -3,7 +3,7 @@
   "id": "mii-ig-onko-de-v2025",
   "language": "de-DE",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-onko/ImplementationGuide/mii-ig-onko-de-v2025",
-  "version": "2026.0.0-rc.7",
+  "version": "2026.0.0-rc.9",
   "name": "MII_IG_Onko_DE",
   "title": "MII IG Onkologie",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-onko-tumorkonferenz.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-onko-tumorkonferenz.json
@@ -214,6 +214,10 @@
             {
               "type": "exists",
               "path": "detail"
+            },
+            {
+              "type": "profile",
+              "path": "reference.resolve()"
             }
           ],
           "rules": "open"

--- a/input/fsh/oBDS/18_19_Tumorkonferenz/mii-pr-onko-tumorkonferenz.fsh
+++ b/input/fsh/oBDS/18_19_Tumorkonferenz/mii-pr-onko-tumorkonferenz.fsh
@@ -41,8 +41,11 @@ Description: "Dieses Profil beschreibt die Tumorkonferenz und die Therapieempfeh
 * activity 0..* MS
 
 // Activity slicing: support both oBDS standard and extended molecular recommendations
-* activity ^slicing.discriminator.type = #exists
-* activity ^slicing.discriminator.path = "detail"
+* activity ^slicing.discriminator[0].type = #exists
+* activity ^slicing.discriminator[0].path = "detail"
+// Additional discriminator for child profiles (e.g., MTB) to differentiate by referenced profile
+* activity ^slicing.discriminator[1].type = #profile
+* activity ^slicing.discriminator[1].path = "reference.resolve()"
 * activity ^slicing.rules = #open
 * activity ^short = "Therapy recommendations - either oBDS standard categorization or extended molecular protocols"
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "de.medizininformatikinitiative.kerndatensatz.onkologie",
-  "version": "2026.0.0-rc.7",
-  "description": "MII Onkologie v2026.0.0-rc.7: Korrektur der Biobank-Dependency Version",
+  "version": "2026.0.0-rc.9",
+  "description": "MII Onkologie v2026.0.0-rc.9: Add profile discriminator to Tumorkonferenz for MTB compatibility",
   "author": "thomasdebertshaeuser",
   "fhirVersions": [
     "4.0.1"

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: MII_IG_Onko_DE
 title: MII IG Onkologie
 # description: Example Implementation Guide for getting started with SUSHI
 status: active # draft | active | retired | unknown
-version: "2026.0.0-rc.7" 
+version: "2026.0.0-rc.9" 
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 copyrightYear: 2022+
 releaseLabel: ci-build # ci-build | draft | qa-preview | ballot | trial-use | release | update | normative+trial-use


### PR DESCRIPTION
## Summary
- Add profile discriminator to Tumorkonferenz activity slicing for MTB compatibility

This release adds a second slicing discriminator (`profile:reference.resolve()`) to the `activity` element in `MII_PR_Onko_Tumorkonferenz`. This enables child profiles like MTB to further slice activity entries by referenced profile type without causing snapshot generation errors.

## Changes
- Added `activity ^slicing.discriminator[1].type = #profile` and `activity ^slicing.discriminator[1].path = "reference.resolve()"` to allow child profiles to use profile-based slicing

## Test plan
- [x] SUSHI compiles without errors
- [ ] CI validation passes
- [ ] MTB module can successfully extend this profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)